### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = ""

--- a/README.md
+++ b/README.md
@@ -34,3 +34,4 @@ python setup.py install.
 Run the Python Script 'SpeedTest.py'
 ================
 ------------------------------------
+[![Run on Repl.it](https://repl.it/badge/github/NotSharwan/Internet-SpeedTest-Python)](https://repl.it/github/NotSharwan/Internet-SpeedTest-Python)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@SharwanSolanki/Internet-SpeedTest-Python).